### PR TITLE
Use the proper git name ansibleplaybookbundle/rhscl-postgresql-apb

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,9 @@
 provision: mediawiki123-apb
-provision: rthallisey/service-broker-ci/postgresql
+provision: ansibleplaybookbundle/rhscl-postgresql-apb
 
-bind: rthallisey/service-broker-ci/postgresql
+bind: ansibleplaybookbundle/rhscl-postgresql-apb
 verify: rthallisey/service-broker-ci/verify-mediawiki-postgresql.sh
 unbind: postgresql | mediawiki123-apb
 
 deprovision: mediawiki123-apb
-deprovision: rthallisey/service-broker-ci/postgresql
+deprovision: ansibleplaybookbundle/rhscl-postgresql-apb


### PR DESCRIPTION
Now that https://github.com/ansibleplaybookbundle/mediawiki123-apb/pull/8 has merged, use the pull git name.